### PR TITLE
Chore / Add Github Workflow Templates for PRs and Issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,24 @@
+## Description
+
+_Rough description of the issue_
+
+## Relevant Context
+
+_Where do expect this work to take place? What files (or even functions within files) will this affect?_
+
+## Steps to Solution(s)
+
+_Steps needed to deliver this issue, psuedo code, pre-planning_
+
+## Links to Resources
+
+_Any links helpful to solving this issue._
+[example link](https://www.google.com)
+
+## QA Testing Steps
+
+_Steps for the QA team to follow to test this feature_
+
+1. Pull in the changes to your local copy of this branch.
+2.
+3.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Changes
+_List Changes Introduced by this PR_
+1. Item 1
+2. Item 2
+
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
+
+## Approach
+_How does this change address the problem?_
+
+## Pre-Testing TODOs
+_What needs to be done before testing_
+- [] Change database values in x collection to y.
+
+## Testing Steps
+_How do the users test this change?_
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+_If this closes an issue, name it here. If it doesn't, remove this line_
+Closes #000


### PR DESCRIPTION
## Changes
1. Added Github workflow templates for `pull request` and `issues`.

## Purpose
Update Github workflow simplicity.

## Approach
Templates for Github workflows are attached under a folder named `.github/`. These templates are then mark down files that are saved into this folder.

## Testing Steps
1. Go to Github.
2. Open an issue and confirm a template is pre-populated in the description.
3. Open a pull request and confirm a template is pre-populated in the description.

Closes #31 